### PR TITLE
Updates to README and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# `atomist/github-auto-merge-skill`
+
+Automatically merge pull requests that pass all checks required to merge.
+
+## Overview
+
+<!---atomist-skill-readme:start--->
+
 Automatically merge pull requests on GitHub based on assigned labels. Required reviews 
 and checks settings configured in the repository on GitHub are used as the rules for auto 
 merging. 
@@ -17,7 +25,8 @@ To enable auto-merging, one the following labels needs to be assigned to the pul
 
 ### Default Auto-merge Policy
 
-To set the default policy to use when auto-merging pull requests when no explicit auto-merge label is applied to the pull request, select one of the options.
+To set the default policy to use when auto-merging pull requests when no explicit auto-merge label is applied to the 
+pull request, select one of the options.
 
 ### Default Auto-merge Method
 
@@ -37,3 +46,13 @@ choose organization(s) and repositories.
 
 The labels are automatically added to and removed from the repository depending on its settings.
 For example, disabling the _rebase_ merge method in the repository settings will automatically remove the label.
+
+<!---atomist-skill-readme:end--->
+
+---
+
+Created by [Atomist][atomist].
+Need Help?  [Join our Slack workspace][slack].
+
+[atomist]: https://atomist.com/ (Atomist - How Teams Deliver Software)
+[slack]: https://join.atomist.com/ (Atomist Community Slack) 

--- a/atomist.yaml
+++ b/atomist.yaml
@@ -35,7 +35,6 @@ skill:
   license: Apache-2.0
   homepage: https://github.com/atomist-skills/auto-merge-skill
   repository: https://github.com/atomist-skills/auto-merge-skill.git
-  #icon: https://images.atomist.com/rug/pull-request.png
   icon: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAiIGhlaWdodD0iMTYwIiB2aWV3Qm94PSIwIDAgMTIgMTYiPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTExIDExLjI4VjVjLS4wMy0uNzgtLjM0LTEuNDctLjk0LTIuMDZDOS40NiAyLjM1IDguNzggMi4wMyA4IDJIN1YwTDQgM2wzIDNWNGgxYy4yNy4wMi40OC4xMS42OS4zMS4yMS4yLjMuNDIuMzEuNjl2Ni4yOEExLjk5MyAxLjk5MyAwIDAgMCAxMCAxNWExLjk5MyAxLjk5MyAwIDAgMCAxLTMuNzJ6bS0xIDIuOTJjLS42NiAwLTEuMi0uNTUtMS4yLTEuMiAwLS42NS41NS0xLjIgMS4yLTEuMi42NSAwIDEuMi41NSAxLjIgMS4yIDAgLjY1LS41NSAxLjItMS4yIDEuMnpNNCAzYzAtMS4xMS0uODktMi0yLTJhMS45OTMgMS45OTMgMCAwIDAtMSAzLjcydjYuNTZBMS45OTMgMS45OTMgMCAwIDAgMiAxNWExLjk5MyAxLjk5MyAwIDAgMCAxLTMuNzJWNC43MmMuNTktLjM0IDEtLjk4IDEtMS43MnptLS44IDEwYzAgLjY2LS41NSAxLjItMS4yIDEuMi0uNjUgMC0xLjItLjU1LTEuMi0xLjIgMC0uNjUuNTUtMS4yIDEuMi0xLjIuNjUgMCAxLjIuNTUgMS4yIDEuMnpNMiA0LjJDMS4zNCA0LjIuOCAzLjY1LjggM2MwLS42NS41NS0xLjIgMS4yLTEuMi42NSAwIDEuMi41NSAxLjIgMS4yIDAgLjY1LS41NSAxLjItMS4yIDEuMnoiLz48L3N2Zz4=
 
   package:
@@ -76,7 +75,7 @@ parameters:
           value: rebase
       required: false
   - repo_filter:
-    name: repos
-    display_name: Which repositories
-    description:
-    required: false
+      name: repos
+      display_name: Which repositories
+      description: ''
+      required: false


### PR DESCRIPTION
* Restructured README header, footer and headings for use in web-app-cljs
* Copy updates on README to clarify usage, list all configuration parameters
* Removed 'GitHub' from the skill name. This is currently redundant since we only support GitHub. Eventually we will have required integration/provider config which can be used to disambiguate which provider this works on (potentially, desirably, this skill would be evolved to work with all supported git providers).
* Updated categories to match the spec
* Re-ordered parameters so that repository selector is last (always should be last)
* Other copy edits